### PR TITLE
added cloudbuild.yaml for building train and predict images in gcp 

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,9 +1,9 @@
 steps:
-- name: 'build train docker image'
+- name: "gcr.io/cloud-builders/docker"
   args: ['build', '--file', './dockerfiles/train_model.dockerfile', '-t', 'gcr.io/firm-catalyst-410709/piano-video-train', '.']
-- name: 'build predict docker image'
+- name: "gcr.io/cloud-builders/docker"
   args: ['build', '--file', './dockerfiles/predict_model.dockerfile', '-t', 'gcr.io/firm-catalyst-410709/piano-video-predict', '.']
-- name: 'push trainer docker image'
+- name: "gcr.io/cloud-builders/docker"
   args: ['push', 'gcr.io/firm-catalyst-410709/piano-video-train']
-- name: 'push predict docker image'
+- name: "gcr.io/cloud-builders/docker"
   args: ['push', 'gcr.io/firm-catalyst-410709/piano-video-predict']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,9 @@
 steps:
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '--file', './dockerfiles/train_model.dockerfile', '-t', 'gcr.io/firm-catalyst-410709/piano-video', '.']
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['push', 'gcr.io/firm-catalyst-410709/piano-video']
+- name: 'build train docker image'
+  args: ['build', '--file', './dockerfiles/train_model.dockerfile', '-t', 'gcr.io/firm-catalyst-410709/piano-video-train', '.']
+- name: 'build predict docker image'
+  args: ['build', '--file', './dockerfiles/predict_model.dockerfile', '-t', 'gcr.io/firm-catalyst-410709/piano-video-predict', '.']
+- name: 'push trainer docker image'
+  args: ['push', 'gcr.io/firm-catalyst-410709/piano-video-train']
+- name: 'push predict docker image'
+  args: ['push', 'gcr.io/firm-catalyst-410709/piano-video-predict']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,6 @@
+steps:
+# some comment
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/firm-catalyst-410709/piano-video', '.']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['push', 'gcr.io/firm-catalyst-410709/piano-video']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,4 @@
 steps:
-# some comment
 - name: 'gcr.io/cloud-builders/docker'
   args: ['build', '-t', 'gcr.io/firm-catalyst-410709/piano-video', '.']
 - name: 'gcr.io/cloud-builders/docker'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/firm-catalyst-410709/piano-video', '.']
+  args: ['build', '--file', './dockerfiles/train_model.dockerfile', '-t', 'gcr.io/firm-catalyst-410709/piano-video', '.']
 - name: 'gcr.io/cloud-builders/docker'
   args: ['push', 'gcr.io/firm-catalyst-410709/piano-video']


### PR DESCRIPTION
- Added cloudbuild.yaml file to build and push train and test docker images. This yaml file will build two images in Container registry named piano-video-train and piano-video-predict if you haven't routed the Container Registry to Artifact Registry else they will be in Artifact Registry.
- The docker train image won't run since there is no data in ./data/images_small
- The docker train image won't run since there is wandb.init() requires an api key. One way to solve that is to run the image by `docker run -e WANDB_API_KEY=<your-api-key> wandb:latest`